### PR TITLE
Add preRenderFunction to config

### DIFF
--- a/jquery.swiftype.search.js
+++ b/jquery.swiftype.search.js
@@ -163,6 +163,10 @@
       });
 
       var renderSearchResults = function (data) {
+          if (typeof config.preRenderFunction === 'function') {
+            config.preRenderFunction.call($this, data);
+          }
+
           $resultContainer.html('');
           $.each(data.records, function (documentType, items) {
             $.each(items, function (idx, item) {
@@ -228,6 +232,7 @@
     sortField: undefined,
     sortDirection: undefined,
     fetchFields: undefined,
+    preRenderFunction: undefined,
     renderFunction: defaultRenderFunction
   };
 })(jQuery);


### PR DESCRIPTION
`preRenderFunction` gets called before the renderer with the data object as a param, so you can manipulate the data. I use it to pull out "top results" for a query and display them in another container.
