### PR TITLE
Override Loading Function

### DIFF
--- a/jquery.swiftype.search.js
+++ b/jquery.swiftype.search.js
@@ -87,7 +87,7 @@
             $resultContainer.after("<div id='" + contentCacheId + "' style='display: none;'></div>");
             $contentCache.html(initialContentOfResultContainer).hide();
           }
-          $resultContainer.html('<p class="st-loading-message">loading...</p>');
+          config.loadingFunction(query, $resultContainer);
 
           Swiftype.currentQuery = query;
           params['q'] = query;
@@ -222,6 +222,10 @@
       return '<div class="st-result"><h3 class="title"><a href="' + item['url'] + '" class="st-search-result-link">' + item['title'] + '</a></h3></div>';
     };
 
+  var defaultLoadingFunction = function(query, $resultContainer) {
+      $resultContainer.html('<p class="st-loading-message">loading...</p>');
+    };
+
   $.fn.swiftypeSearch.defaults = {
     attachTo: undefined,
     documentTypes: undefined,
@@ -233,6 +237,7 @@
     sortDirection: undefined,
     fetchFields: undefined,
     preRenderFunction: undefined,
+    loadingFunction: defaultLoadingFunction,
     renderFunction: defaultRenderFunction
   };
 })(jQuery);


### PR DESCRIPTION
The current functionality just prints "Loading...", which has some issues:
- Resizes the page when load starts and finishes (height changes can be jarring)
- Can't be translated
- Not too nice UI wise

We use the new loadingFunction to override that functionality and display a spinner instead of a text message, as well as not removing the current results till the new ones are ready to render, avoiding a page height shift.
