### PR TITLE
Fix pagination links generation

### DIFF
--- a/jquery.swiftype.search.js
+++ b/jquery.swiftype.search.js
@@ -178,6 +178,7 @@
     $.each(resultInfo, function(documentType, typeInfo) {
       if (typeInfo.num_pages > maxPages) {
         maxPagesType = documentType;
+        maxPages = typeInfo.num_pages;
       }
     });
     var currentPage = resultInfo[maxPagesType].current_page,


### PR DESCRIPTION
The last type would always be considered the one with the most results (pages).
