### PR TITLE
Encode query search string

### DIFF
--- a/jquery.swiftype.search.js
+++ b/jquery.swiftype.search.js
@@ -73,7 +73,7 @@
         $contentCache = $this.getContentCache();
 
       var setSearchHash = function (query, page) {
-          location.hash = "stq=" + query + "&stp=" + page;
+          location.hash = "stq=" + encodeURIComponent(query) + "&stp=" + page;
         };
 
       var submitSearch = function (query, options) {


### PR DESCRIPTION
The query search string (stq) is not encoded when setting location.hash causing decodeURIComponent to throw errors (URIError) sometimes since for example Safari tries to autoencode special characters a way that is not supported by decodeURIComponent
