### PR TITLE
Fixing the 404 error because of old/bad api url

### DIFF
--- a/jquery.swiftype.search.js
+++ b/jquery.swiftype.search.js
@@ -21,7 +21,7 @@
 
 
   window.Swiftype = window.Swiftype || {};
-  Swiftype.root_url = Swiftype.root_url || 'https://api.swiftype.com';
+  Swiftype.root_url = Swiftype.root_url || 'https://search-api.swiftype.com';
   Swiftype.pingUrl = function(endpoint, callback) {
     var to = setTimeout(callback, 350);
     var img = new Image();
@@ -121,7 +121,7 @@
 
           $.ajax({
             dataType: "json",
-            url: Swiftype.root_url + "/api/v1/public/engines/search.json?callback=?",
+            url: Swiftype.root_url + '/api/v1/public/installs/' + params['engine_key'] + '/search.json?callback=?',
             data: params,
             xhrFields: { withCredentials: true },
             success: renderSearchResults


### PR DESCRIPTION
#### Actual behavior:

When submitting searched content in the search input field, having a `404 not found` in the requested URL below:
```
https://search-api.swiftype.com/api/v1/public/engines/[ENGINE_KEY_HERE]/search.json?callback=jQuery331069105185093093_1556543702623&q=abc&engine_key=[ENGINE_KEY_HERE]&page=1&per_page=10&spelling=strict&_=1556543702627
```
#### Wanted behaviour:

Getting a `200` response when looking for autocomplete

#### How this PR fixes the issue ?

This pull request fixes the issue by updating the requested API url. I tested it in the project we're working on, and it worked.