### PR TITLE
Added global Swiftype.reloadResults method

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,6 +172,16 @@ $('#st-search-input').swiftypeSearch({
 });
 ```
 
+### Triggering a new query
+
+In come cases, you may need to manually trigger a new search. The following method can be
+used to do so. An example of such a case would be if a user chooses to apply a filter
+and a new query needs top be executed.
+
+```
+Swiftype.reloadResults();
+```
+
 ## FAQ 🔮
 
 ### Can I use this with the Swiftype Autocomplete Plugin?

--- a/jquery.swiftype.search.js
+++ b/jquery.swiftype.search.js
@@ -143,6 +143,9 @@
         }
       }
 
+      // Expose this globally for users to force a refresh of search results.
+      Swiftype.reloadResults = handleHashchange;
+
       $(window).on("hashchange", handleHashchange);
 
       var $containingForm = $this.parents('form');


### PR DESCRIPTION
Since removing the hash change jquery plugin, we needed
some way to re-trigger a query. This was previously done by
running `$(window).hashchange();`

This corresponds to updates I'm making in our documentation:
https://github.com/swiftype/documentation/pull/380